### PR TITLE
Allow empty slices for commit parents

### DIFF
--- a/src/repository.zig
+++ b/src/repository.zig
@@ -1551,7 +1551,7 @@ pub const Repository = opaque {
             message.ptr,
             @ptrCast(*const c.git_tree, tree),
             parents.len,
-            @ptrCast([*]?*const c.git_commit, parents.ptr),
+            @ptrCast(?[*]?*const c.git_commit, parents.ptr),
         });
 
         return ret;
@@ -1581,7 +1581,7 @@ pub const Repository = opaque {
             message.ptr,
             @ptrCast(*const c.git_tree, tree),
             parents.len,
-            @ptrCast([*]?*const c.git_commit, parents.ptr),
+            @ptrCast(?[*]?*const c.git_commit, parents.ptr),
         });
 
         return ret;


### PR DESCRIPTION
libgit2 allows the `parents` pointer to be null if there are 0 parents,
and Zig may set `ptr` to null for zero-length slices:
https://github.com/ziglang/zig/issues/4771